### PR TITLE
Upgrade primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "codechain-crypto"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["CodeChain Team <hi@codechain.io>"]
 edition = "2018"
 
 [dependencies]
 ring = "0.14.6"
 quick-error = "1.2"
-primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
+primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.5" }
 sha-1 = "0.8.2"
 sha2 = "0.8.1"
 sha3 = "0.8.2"

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -31,7 +31,7 @@ type Aes128Ctr = ctr::Ctr128<Aes128>;
 
 // AES-256/CBC/Pkcs encryption.
 pub fn encrypt(data: &[u8], key: &H256, iv: &u128) -> Result<Vec<u8>, InvalidKeyIvLength> {
-    let cipher = Aes256Cbc::new_var(&key, &iv.to_be_bytes())?;
+    let cipher = Aes256Cbc::new_var(key.as_ref(), &iv.to_be_bytes())?;
     let result = cipher.encrypt_vec(data);
 
     Ok(result)
@@ -39,7 +39,7 @@ pub fn encrypt(data: &[u8], key: &H256, iv: &u128) -> Result<Vec<u8>, InvalidKey
 
 // AES-256/CBC/Pkcs decryption.
 pub fn decrypt(encrypted_data: &[u8], key: &H256, iv: &u128) -> Result<Vec<u8>, InvalidKeyIvLength> {
-    let cipher = Aes256Cbc::new_var(&key, &iv.to_be_bytes())?;
+    let cipher = Aes256Cbc::new_var(key.as_ref(), &iv.to_be_bytes())?;
     let result = cipher.decrypt_vec(&encrypted_data.to_vec()).unwrap();
 
     Ok(result)
@@ -102,7 +102,7 @@ mod tests {
         // a password. For the purposes of this example, the key and
         // iv are just random values.
         let mut rng = OsRng::new().ok().unwrap();
-        rng.fill_bytes(&mut key);
+        rng.fill_bytes(key.as_mut());
         let iv = rng.gen();
 
         let encrypted_data = encrypt(message.as_bytes(), &key, &iv).ok().unwrap();
@@ -118,7 +118,7 @@ mod tests {
         let mut key = H256([0; 32]);
 
         let mut rng = OsRng::new().unwrap();
-        rng.fill_bytes(&mut key);
+        rng.fill_bytes(key.as_mut());
         let iv = rng.gen();
 
         let encrypted = encrypt(&input, &key, &iv).unwrap();

--- a/src/blake.rs
+++ b/src/blake.rs
@@ -94,25 +94,26 @@ pub const BLAKE_EMPTY_LIST_RLP: H256 = H256([
 #[cfg(test)]
 mod tests {
     use std::panic::catch_unwind;
+    use std::str::FromStr;
 
     use super::*;
 
     #[test]
     fn _blake128() {
         let result = H128::blake(b"hello");
-        assert_eq!(H128::from("46fb7408d4f285228f4af516ea25851b"), result);
+        assert_eq!(H128::from_str("46fb7408d4f285228f4af516ea25851b").unwrap(), result);
     }
 
     #[test]
     fn _blake256() {
-        let expected = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf".into();
+        let expected = H256::from_str("324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf").unwrap();
         let result = blake256(b"hello");
         assert_eq!(result, expected);
     }
 
     #[test]
     fn _blake512() {
-        let expected = "e4cfa39a3d37be31c59609e807970799caa68a19bfaa15135f165085e01d41a65ba1e1b146aeb6bd0092b49eac214c103ccfa3a365954bbbe52f74a2b3620c94".into();
+        let expected = H512::from_str("e4cfa39a3d37be31c59609e807970799caa68a19bfaa15135f165085e01d41a65ba1e1b146aeb6bd0092b49eac214c103ccfa3a365954bbbe52f74a2b3620c94").unwrap();
         let result = blake512(b"hello");
         assert_eq!(result, expected);
     }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -67,32 +67,33 @@ pub fn keccak256<T: AsRef<[u8]>>(s: T) -> H256 {
 
 #[cfg(test)]
 mod tests {
-    use super::{keccak256, ripemd160, sha1, sha256};
+    use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn _ripemd160() {
-        let expected = "108f07b8382412612c048d07d13f814118445acd".into();
+        let expected = H160::from_str("108f07b8382412612c048d07d13f814118445acd").unwrap();
         let result = ripemd160(b"hello");
         assert_eq!(result, expected);
     }
 
     #[test]
     fn _sha1() {
-        let expected = "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d".into();
+        let expected = H160::from_str("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d").unwrap();
         let result = sha1(b"hello");
         assert_eq!(result, expected);
     }
 
     #[test]
     fn _sha256() {
-        let expected = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824".into();
+        let expected = H256::from_str("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824").unwrap();
         let result = sha256(b"hello");
         assert_eq!(result, expected);
     }
 
     #[test]
     fn _keccak256() {
-        let expected = "1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8".into();
+        let expected = H256::from_str("1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8").unwrap();
         let result = keccak256(b"hello");
         assert_eq!(result, expected);
     }


### PR DESCRIPTION
The latest hashes don't implement `Deref` anymore. This makes the caller use `AsRef` and `AsMut` instead of it.
And there is no more `From` to convert a string to a hash. You should `FromStr` instead of it.